### PR TITLE
Improve docker build performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,12 @@
-ARG GO_VERSION=latest
-ARG DISTROLESS_IMAGE=gcr.io/distroless/static
-ARG DISTROLESS_IMAGE_TAG=nonroot
-ARG UPX_OPTION=-9
-ARG MAINTAINER="rytswd <rytswd@gmail.com>,hlts2 <hiroto.funakoshi.hiroto@gmail.com>"
+ARG GO_VERSION=1.16.7
 
-FROM golang:${GO_VERSION} AS builder
-
-ARG UPX_OPTIONS
+FROM golang:${GO_VERSION}-alpine
 
 ENV GO111MODULE on
 ENV LANG en_US.UTF-8
 ENV ORG upsidr
 ENV REPO merge-gatekeeper
 ENV APP_NAME merge-gatekeeper
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    upx \
-    git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p $GOPATH/src
 
@@ -38,15 +26,6 @@ COPY internal .
 WORKDIR ${GOPATH}/src/github.com/${ORG}/${REPO}
 
 RUN CGO_ENABLED=0 go build ./cmd/${APP_NAME} \
-    && upx ${UPX_OPTIONS} -o "/usr/bin/${APP_NAME}" "${APP_NAME}"
-
-FROM ${DISTROLESS_IMAGE}:${DISTROLESS_IMAGE_TAG}
-LABEL maintainer "${MAINTAINER}"
-
-ENV APP_NAME merge-gatekeeper
-
-COPY --from=builder /usr/bin/${APP_NAME} /go/bin/${APP_NAME}
-
-USER nonroot:nonroot
+    && mv ${APP_NAME} /go/bin/
 
 ENTRYPOINT ["/go/bin/merge-gatekeeper"]


### PR DESCRIPTION
## WHY

If we specify a dockerfile in the actions yaml, it will be docker built every time the job runs. So, using multistage will not improve performance. (This is effective when pulling from docker hub)

## WHAT

delete multistage build


