### PR TITLE
Limit Go build trigger to be only for Go related code

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
       - release/v*
+    paths:
+      - cmd/**
+      - internal/**
+      - go.mod
+      - go.sum
 
 env:
   GO_VERSION: 1.16.7


### PR DESCRIPTION
# WHAT

As titled

# WHY

When it's about documentation change only, we would not need to run Go build