### PR TITLE
Require importer run only when markdown change is included

### DIFF
--- a/.github/workflows/documentation-ci.yaml
+++ b/.github/workflows/documentation-ci.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**.md"
 
 jobs:
   importer:


### PR DESCRIPTION
# WHAT

As titled

# WHY

Importer runs are not needed for non-markdown files. This may change in the future, but for now this is safe assumption.