### PR TITLE
Fix job name format of status validator

### DIFF
--- a/internal/validators/status/status.go
+++ b/internal/validators/status/status.go
@@ -14,11 +14,11 @@ func (s *status) Detail() string {
 		`%d out of %d
 
   total job count: %d
-    jobs: %v
+    jobs: %+q
   completed job count: %d
-    jobs: %v
+    jobs: %+q
   failed job count: %d
-    jobs: %v`,
+    jobs: %+q`,
 		len(s.completeJobs), len(s.totalJobs),
 		len(s.totalJobs), s.totalJobs,
 		len(s.completeJobs), s.completeJobs,

--- a/internal/validators/status/status_test.go
+++ b/internal/validators/status/status_test.go
@@ -26,11 +26,11 @@ func Test_status_Detail(t *testing.T) {
 			want: `1 out of 3
 
   total job count: 3
-    jobs: [job-1 job-2 job-3]
+    jobs: ["job-1" "job-2" "job-3"]
   completed job count: 1
-    jobs: [job-2]
+    jobs: ["job-2"]
   failed job count: 1
-    jobs: [job-3]`,
+    jobs: ["job-3"]`,
 		},
 		"return detail when totalJobs and completeJobs is empty": {
 			s: &status{


### PR DESCRIPTION
I had verbally said before that I would cut it out into a separate function and output the job name one line at a time, but there was a concern that as the number of jobs increased, it would become difficult to see the different status fields, so I thought again that it would be better to display them on a single line, so I responded with a simple implementation.