### PR TITLE
fix typo on ignored arg

### DIFF
--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -24,7 +24,7 @@ var (
 	timeoutSecond       uint
 	validateInvalSecond uint
 	selfJobName         string
-	ignoreJobs          string
+	ignoredJobs         string
 )
 
 func validateCmd() *cobra.Command {
@@ -49,7 +49,7 @@ func validateCmd() *cobra.Command {
 				status.WithSelfJob(selfJobName),
 				status.WithGitHubOwnerAndRepo(owner, repo),
 				status.WithGitHubRef(ghRef),
-				status.WithIgnoredJobs(ignoreJobs),
+				status.WithIgnoredJobs(ignoredJobs),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create validator: %w", err)
@@ -70,7 +70,7 @@ func validateCmd() *cobra.Command {
 	cmd.PersistentFlags().UintVar(&timeoutSecond, "timeout", 600, "set validate timeout second")
 	cmd.PersistentFlags().UintVar(&validateInvalSecond, "interval", 10, "set validate interval second")
 
-	cmd.PersistentFlags().StringVarP(&ignoreJobs, "ignore", "i", "", "set ignored jobs (comma-separated list)")
+	cmd.PersistentFlags().StringVarP(&ignoredJobs, "ignored", "i", "", "set ignored jobs (comma-separated list)")
 
 	return cmd
 }


### PR DESCRIPTION
Following https://github.com/upsidr/merge-gatekeeper/pull/30

My bad, the new cli arg was not working. correctly use `ignored` on cli args too.