### PR TITLE
Add leading and trailing space handling for ignored jobs, and add some more tests

### DIFF
--- a/internal/validators/status/option.go
+++ b/internal/validators/status/option.go
@@ -33,6 +33,7 @@ func WithGitHubRef(ref string) Option {
 
 func WithIgnoredJobs(names string) Option {
 	return func(s *statusValidator) {
+		// TODO: Add more input validation, such as "," should not be a valid input.
 		if len(names) != 0 {
 			s.ignoredJobs = strings.Split(names, ",")
 		}

--- a/internal/validators/status/status.go
+++ b/internal/validators/status/status.go
@@ -28,5 +28,6 @@ func (s *status) Detail() string {
 }
 
 func (s *status) IsSuccess() bool {
+	// TDOO: Add test case
 	return s.succeeded
 }

--- a/internal/validators/status/validator.go
+++ b/internal/validators/status/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/upsidr/merge-gatekeeper/internal/github"
 	"github.com/upsidr/merge-gatekeeper/internal/multierror"
@@ -110,7 +111,7 @@ func (sv *statusValidator) Validate(ctx context.Context) (validators.Status, err
 	for _, ghaStatus := range ghaStatuses {
 		var toIgnore bool
 		for _, ignored := range sv.ignoredJobs {
-			if ghaStatus.Job == ignored {
+			if ghaStatus.Job == strings.TrimSpace(ignored) {
 				toIgnore = true
 				break
 			}


### PR DESCRIPTION
Update
- Handle leading and trailing whitespaces in the list of ignored jobs, as the csv string input would be easier to manage with extra spaces.
- Add more test coverage for some code paths that weren't tested
- Add some comments for future test and validation improvements