### PR TITLE
Support spaces and newlines in ignored jobs

### DIFF
--- a/internal/validators/status/option.go
+++ b/internal/validators/status/option.go
@@ -40,7 +40,5 @@ func WithIgnoredJobs(names string) Option {
 				s.ignoredJobs = append(s.ignoredJobs, strings.TrimSpace(job))
 			}
 		}
-
-		fmt.Printf("%v", s.ignoredJobs)
 	}
 }


### PR DESCRIPTION
Similar to #39, this PR removes trailling and leading whitespace from ignored job. It also adds support for using newlines in the ignored jobs. This should allow users to use merge gatekeeper in the following way:

```yml
jobs:
  merge-gatekeeper:
    runs-on: ubuntu-latest
    steps:
      - name: Run Merge Gatekeeper
        uses: upsidr/merge-gatekeeper@v1
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          ignored: |
            my_job1,
            my_job2,
            my_job3
```