### PR TITLE
Add clarification and example for matrix strategy

### DIFF
--- a/.github/workflows/issue-27.yaml
+++ b/.github/workflows/issue-27.yaml
@@ -1,0 +1,35 @@
+---
+name: Matrix Test
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  matrix-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        m-abc:
+          - "a"
+          - "b"
+          - "c"
+          - "d"
+          - "e"
+        m-xyz:
+          - "x"
+          - "y"
+          - "z"
+      fail-fast: false
+    steps:
+      - run: |
+          echo "Running matrix based test"
+          echo
+          echo "  m-abc: ${{ matrix.m-abc }}"
+          echo "  m-xyz: ${{ matrix.m-xyz }}"
+
+          # Below is for testing failure handling. Commented out for this.
+
+          # Force fail if input is "a" and "z"
+          # if [[ ${{ matrix.m-abc }} == "a" && ${{ matrix.m-xyz }} == "z" ]]; then return 1; fi

--- a/docs/action-usage.md
+++ b/docs/action-usage.md
@@ -35,6 +35,7 @@ curl -sSL https://raw.githubusercontent.com/upsidr/merge-gatekeeper/main/example
 The below is the copy of [`/example/merge-gatekeeper.yml`](/example/merge-gatekeeper.yml), with extra comments.
 
 <!-- == imptr: basic-yaml / begin from: ../example/definitions.yaml#[standard-setup] wrap: yaml == -->
+
 ```yaml
 ---
 name: Merge Gatekeeper
@@ -57,6 +58,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
 <!-- == imptr: basic-yaml / end == -->
 
 <!-- == export: simple-usage / end == -->
@@ -74,4 +76,6 @@ Create a YAML file with just a single Importer Marker:
 
 With that, you can simply run `importer update FILENAME` to get the latest spec. You can also update the file used to specific branch or version.
 
-###
+### Use with matrix strategy
+
+Merge Gatekeeper supports the use of matrix strategy. If any of the job fails, Merge Gatekeeper will also fail. In case of a complex matrix setup where one entry is not going to be needed, you may need to tweak Merge Gatekeeper spec to ignore some errors.


### PR DESCRIPTION
Fixes #27 

- A simple example job has been added (which will be run every time a commit is pushed to master)
- A quick documentation has been added for matrix use case

Side Note
After writing the doc above, I realise how "ignore" setup would probably need to support a bit more sophisticated input such as regex - otherwise it would be really difficult to use when you want to test an extra matrix strategy and do not care errors from those. I will leave that as a separate ticket.