### PR TITLE
Support more than 30 status

### DIFF
--- a/internal/validators/status/validator.go
+++ b/internal/validators/status/validator.go
@@ -157,7 +157,7 @@ func (sv *statusValidator) listGhaStatuses(ctx context.Context) ([]*ghaStatus, e
 
 		combined = append(combined, c.Statuses...)
 
-		if c.GetTotalCount() <= 100 {
+		if c.GetTotalCount() < 100 {
 			break
 		}
 		page++

--- a/internal/validators/status/validator_test.go
+++ b/internal/validators/status/validator_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -725,6 +726,147 @@ func Test_statusValidator_listStatues(t *testing.T) {
 						State: errorState,
 					},
 				},
+			}
+		}(),
+		"succeeds to retrieve 100 statuses": func() test {
+			num_statuses := 100
+			statuses := make([]*github.RepoStatus, num_statuses)
+			checkRuns := make([]*github.CheckRun, num_statuses)
+			expectedGhaStatuses := make([]*ghaStatus, num_statuses)
+			for i := 0; i < num_statuses; i++ {
+				statuses[i] = &github.RepoStatus{
+					Context: stringPtr(fmt.Sprintf("job-%d", i)),
+					State:   stringPtr(successState),
+				}
+
+				checkRuns[i] = &github.CheckRun{
+					Name:       stringPtr(fmt.Sprintf("job-%d", i)),
+					Status:     stringPtr(checkRunCompletedStatus),
+					Conclusion: stringPtr(checkRunNeutralConclusion),
+				}
+
+				expectedGhaStatuses[i] = &ghaStatus{
+					Job:   fmt.Sprintf("job-%d", i),
+					State: successState,
+				}
+			}
+
+			c := &mock.Client{
+				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					return &github.CombinedStatus{
+						Statuses: statuses,
+					}, nil, nil
+				},
+				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					return &github.ListCheckRunsResults{
+						CheckRuns: checkRuns,
+					}, nil, nil
+				},
+			}
+			return test{
+				fields: fields{
+					client:      c,
+					selfJobName: "self-job",
+					owner:       "test-owner",
+					repo:        "test-repo",
+					ref:         "main",
+				},
+				wantErr: false,
+				want:    expectedGhaStatuses,
+			}
+		}(),
+		"succeeds to retrieve 162 statuses": func() test {
+			num_statuses := 162
+			statuses := make([]*github.RepoStatus, num_statuses)
+			checkRuns := make([]*github.CheckRun, num_statuses)
+			expectedGhaStatuses := make([]*ghaStatus, num_statuses)
+			for i := 0; i < num_statuses; i++ {
+				statuses[i] = &github.RepoStatus{
+					Context: stringPtr(fmt.Sprintf("job-%d", i)),
+					State:   stringPtr(successState),
+				}
+
+				checkRuns[i] = &github.CheckRun{
+					Name:       stringPtr(fmt.Sprintf("job-%d", i)),
+					Status:     stringPtr(checkRunCompletedStatus),
+					Conclusion: stringPtr(checkRunNeutralConclusion),
+				}
+
+				expectedGhaStatuses[i] = &ghaStatus{
+					Job:   fmt.Sprintf("job-%d", i),
+					State: successState,
+				}
+			}
+
+			c := &mock.Client{
+				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					return &github.CombinedStatus{
+						Statuses: statuses[(opts.Page-1)*opts.PerPage : opts.Page*opts.PerPage],
+					}, nil, nil
+				},
+				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					return &github.ListCheckRunsResults{
+						CheckRuns: checkRuns,
+					}, nil, nil
+				},
+			}
+			return test{
+				fields: fields{
+					client:      c,
+					selfJobName: "self-job",
+					owner:       "test-owner",
+					repo:        "test-repo",
+					ref:         "main",
+				},
+				wantErr: false,
+				want:    expectedGhaStatuses,
+			}
+		}(),
+		"succeeds to retrieve 587 statuses": func() test {
+			num_statuses := 587
+			statuses := make([]*github.RepoStatus, num_statuses)
+			checkRuns := make([]*github.CheckRun, num_statuses)
+			expectedGhaStatuses := make([]*ghaStatus, num_statuses)
+			for i := 0; i < num_statuses; i++ {
+				statuses[i] = &github.RepoStatus{
+					Context: stringPtr(fmt.Sprintf("job-%d", i)),
+					State:   stringPtr(successState),
+				}
+
+				checkRuns[i] = &github.CheckRun{
+					Name:       stringPtr(fmt.Sprintf("job-%d", i)),
+					Status:     stringPtr(checkRunCompletedStatus),
+					Conclusion: stringPtr(checkRunNeutralConclusion),
+				}
+
+				expectedGhaStatuses[i] = &ghaStatus{
+					Job:   fmt.Sprintf("job-%d", i),
+					State: successState,
+				}
+			}
+
+			c := &mock.Client{
+				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					return &github.CombinedStatus{
+						Statuses: statuses[(opts.Page-1)*opts.PerPage : opts.Page*opts.PerPage],
+					}, nil, nil
+				},
+				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					return &github.ListCheckRunsResults{
+						CheckRuns: checkRuns,
+					}, nil, nil
+				},
+			}
+			return test{
+				fields: fields{
+					client:      c,
+					selfJobName: "self-job",
+					owner:       "test-owner",
+					repo:        "test-repo",
+					ref:         "main",
+				},
+				wantErr: false,
+				want:    expectedGhaStatuses,
 			}
 		}(),
 	}

--- a/internal/validators/status/validator_test.go
+++ b/internal/validators/status/validator_test.go
@@ -16,6 +16,13 @@ func stringPtr(str string) *string {
 	return &str
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func TestCreateValidator(t *testing.T) {
 	tests := map[string]struct {
 		c       github.Client
@@ -753,13 +760,21 @@ func Test_statusValidator_listStatues(t *testing.T) {
 
 			c := &mock.Client{
 				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					max := min(opts.Page*opts.PerPage, len(statuses))
+					sts := statuses[(opts.Page-1)*opts.PerPage : max]
+					l := len(sts)
 					return &github.CombinedStatus{
-						Statuses: statuses,
+						Statuses:   sts,
+						TotalCount: &l,
 					}, nil, nil
 				},
 				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					max := min(opts.ListOptions.Page*opts.ListOptions.PerPage, len(checkRuns))
+					sts := checkRuns[(opts.ListOptions.Page-1)*opts.ListOptions.PerPage : max]
+					l := len(sts)
 					return &github.ListCheckRunsResults{
 						CheckRuns: checkRuns,
+						Total:     &l,
 					}, nil, nil
 				},
 			}
@@ -800,13 +815,21 @@ func Test_statusValidator_listStatues(t *testing.T) {
 
 			c := &mock.Client{
 				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					max := min(opts.Page*opts.PerPage, len(statuses))
+					sts := statuses[(opts.Page-1)*opts.PerPage : max]
+					l := len(sts)
 					return &github.CombinedStatus{
-						Statuses: statuses[(opts.Page-1)*opts.PerPage : opts.Page*opts.PerPage],
+						Statuses:   sts,
+						TotalCount: &l,
 					}, nil, nil
 				},
 				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					max := min(opts.ListOptions.Page*opts.ListOptions.PerPage, len(checkRuns))
+					sts := checkRuns[(opts.ListOptions.Page-1)*opts.ListOptions.PerPage : max]
+					l := len(sts)
 					return &github.ListCheckRunsResults{
 						CheckRuns: checkRuns,
+						Total:     &l,
 					}, nil, nil
 				},
 			}
@@ -847,13 +870,21 @@ func Test_statusValidator_listStatues(t *testing.T) {
 
 			c := &mock.Client{
 				GetCombinedStatusFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+					max := min(opts.Page*opts.PerPage, len(statuses))
+					sts := statuses[(opts.Page-1)*opts.PerPage : max]
+					l := len(sts)
 					return &github.CombinedStatus{
-						Statuses: statuses[(opts.Page-1)*opts.PerPage : opts.Page*opts.PerPage],
+						Statuses:   sts,
+						TotalCount: &l,
 					}, nil, nil
 				},
 				ListCheckRunsForRefFunc: func(ctx context.Context, owner, repo, ref string, opts *github.ListCheckRunsOptions) (*github.ListCheckRunsResults, *github.Response, error) {
+					max := min(opts.ListOptions.Page*opts.ListOptions.PerPage, len(checkRuns))
+					sts := checkRuns[(opts.ListOptions.Page-1)*opts.ListOptions.PerPage : max]
+					l := len(sts)
 					return &github.ListCheckRunsResults{
 						CheckRuns: checkRuns,
+						Total:     &l,
 					}, nil, nil
 				},
 			}


### PR DESCRIPTION
We have a monorepo that currently runs 44 jobs on each PR. This leads to a mismatch between the expected amount of statuses and the current completed amount which makes the gatekeeper pass earlier than expected. The issue is that the status API default size is 30. This PR bumps the `PerPage` size to 100 (max allowed) and adds the necessary page continuation logic to effectively allows for _infinite_ statuses to be retrieved.