### PR TITLE
Improve execution logging

### DIFF
--- a/internal/validators/status/status.go
+++ b/internal/validators/status/status.go
@@ -10,30 +10,67 @@ type status struct {
 	succeeded    bool
 }
 
+func prettyPrintJobList(jobs []string) string {
+	result := ""
+	if len(jobs) == 0 {
+		result = "[]"
+	}
+	for i, job := range jobs {
+		result += fmt.Sprintf("- %s", job)
+		if i != len(jobs)-1 {
+			result += "\n"
+		}
+	}
+
+	return result
+}
+
 func (s *status) Detail() string {
 	result := fmt.Sprintf(
 		`%d out of %d
 
-  Total job count:     %d
-    jobs: %+q
-  Completed job count: %d
-    jobs: %+q
-  Failed job count:    %d
-    jobs: %+q
+Total job count:       %d
+Completed job count:   %d
+Incompleted job count: %d
+Failed job count:      %d
+Ignored job count:     %d
 `,
 		len(s.completeJobs), len(s.totalJobs),
-		len(s.totalJobs), s.totalJobs,
-		len(s.completeJobs), s.completeJobs,
-		len(s.errJobs), s.errJobs,
+		len(s.totalJobs),
+		len(s.completeJobs),
+		len(s.getIncompleteJobs()),
+		len(s.errJobs),
+		len(s.ignoredJobs),
 	)
 
-	if len(s.ignoredJobs) > 0 {
-		result = fmt.Sprintf(
-			`%s
+	result = fmt.Sprintf(`%s
+::group::Failed jobs
+%s
+::endgroup::
 
-  --
-  Ignored jobs: %+q`, result, s.ignoredJobs)
-	}
+::group::Completed jobs
+%s
+::endgroup::
+
+::group::Incomplete jobs
+%s
+::endgroup::
+
+::group::Ignored jobs
+%s
+::endgroup::
+
+::group::All jobs
+%s
+::endgroup::
+`,
+		result,
+		prettyPrintJobList(s.errJobs),
+		prettyPrintJobList(s.completeJobs),
+		prettyPrintJobList(s.getIncompleteJobs()),
+		prettyPrintJobList(s.ignoredJobs),
+		prettyPrintJobList(s.totalJobs),
+	)
 
 	return result
 }
@@ -41,4 +78,36 @@ func (s *status) Detail() string {
 func (s *status) IsSuccess() bool {
 	// TDOO: Add test case
 	return s.succeeded
+}
+
+func (s *status) getIncompleteJobs() []string {
+	var incomplete []string
+
+	for _, job := range s.totalJobs {
+		found := false
+		for _, complete := range s.completeJobs {
+			if job == complete {
+				found = true
+				break
+			}
+		}
+
+		for _, failed := range s.errJobs {
+			if job == failed {
+				found = true
+				break
+			}
+		}
+
+		for _, ignored := range s.ignoredJobs {
+			if job == ignored {
+				found = true
+				break
+			}
+		}
+		if !found {
+			incomplete = append(incomplete, job)
+		}
+	}
+	return incomplete
 }

--- a/internal/validators/status/status_test.go
+++ b/internal/validators/status/status_test.go
@@ -25,12 +25,33 @@ func Test_status_Detail(t *testing.T) {
 			},
 			want: `1 out of 3
 
-  Total job count:     3
-    jobs: ["job-1" "job-2" "job-3"]
-  Completed job count: 1
-    jobs: ["job-2"]
-  Failed job count:    1
-    jobs: ["job-3"]
+Total job count:       3
+Completed job count:   1
+Incompleted job count: 1
+Failed job count:      1
+Ignored job count:     0
+
+::group::Failed jobs
+- job-3
+::endgroup::
+
+::group::Completed jobs
+- job-2
+::endgroup::
+
+::group::Incomplete jobs
+- job-1
+::endgroup::
+
+::group::Ignored jobs
+[]
+::endgroup::
+
+::group::All jobs
+- job-1
+- job-2
+- job-3
+::endgroup::
 `,
 		},
 		"return detail with ignored jobs input": {
@@ -54,16 +75,36 @@ func Test_status_Detail(t *testing.T) {
 			},
 			want: `2 out of 4
 
-  Total job count:     4
-    jobs: ["job-1" "job-2" "job-3" "job-4"]
-  Completed job count: 2
-    jobs: ["job-2" "job-4"]
-  Failed job count:    1
-    jobs: ["job-3"]
+Total job count:       4
+Completed job count:   2
+Incompleted job count: 1
+Failed job count:      1
+Ignored job count:     1
 
+::group::Failed jobs
+- job-3
+::endgroup::
 
-  --
-  Ignored jobs: ["job-4"]`,
+::group::Completed jobs
+- job-2
+- job-4
+::endgroup::
+
+::group::Incomplete jobs
+- job-1
+::endgroup::
+
+::group::Ignored jobs
+- job-4
+::endgroup::
+
+::group::All jobs
+- job-1
+- job-2
+- job-3
+- job-4
+::endgroup::
+`,
 		},
 		"return detail when totalJobs and completeJobs is empty": {
 			s: &status{
@@ -72,12 +113,31 @@ func Test_status_Detail(t *testing.T) {
 			},
 			want: `0 out of 0
 
-  Total job count:     0
-    jobs: []
-  Completed job count: 0
-    jobs: []
-  Failed job count:    0
-    jobs: []
+Total job count:       0
+Completed job count:   0
+Incompleted job count: 0
+Failed job count:      0
+Ignored job count:     0
+
+::group::Failed jobs
+[]
+::endgroup::
+
+::group::Completed jobs
+[]
+::endgroup::
+
+::group::Incomplete jobs
+[]
+::endgroup::
+
+::group::Ignored jobs
+[]
+::endgroup::
+
+::group::All jobs
+[]
+::endgroup::
 `,
 		},
 	}

--- a/internal/validators/status/validator.go
+++ b/internal/validators/status/validator.go
@@ -104,8 +104,11 @@ func (sv *statusValidator) Validate(ctx context.Context) (validators.Status, err
 		totalJobs:    make([]string, 0, len(ghaStatuses)),
 		completeJobs: make([]string, 0, len(ghaStatuses)),
 		errJobs:      make([]string, 0, len(ghaStatuses)/2),
+		ignoredJobs:  make([]string, 0, len(ghaStatuses)),
 		succeeded:    true,
 	}
+
+	st.ignoredJobs = append(st.ignoredJobs, sv.ignoredJobs...)
 
 	var successCnt int
 	for _, ghaStatus := range ghaStatuses {

--- a/internal/validators/status/validator_test.go
+++ b/internal/validators/status/validator_test.go
@@ -184,6 +184,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				succeeded:    true,
 				totalJobs:    []string{},
 				completeJobs: []string{},
+				ignoredJobs:  []string{},
 				errJobs:      []string{},
 			},
 		},
@@ -209,6 +210,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				succeeded:    true,
 				totalJobs:    []string{},
 				completeJobs: []string{},
+				ignoredJobs:  []string{},
 				errJobs:      []string{},
 			},
 		},
@@ -233,6 +235,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				succeeded:    false,
 				totalJobs:    []string{"job"},
 				completeJobs: []string{},
+				ignoredJobs:  []string{},
 				errJobs:      []string{},
 			},
 		},
@@ -272,6 +275,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				errJobs: []string{
 					"job-02",
 				},
+				ignoredJobs: []string{},
 			}).Detail(),
 		},
 		"returns error when there is a failed job with failure state": {
@@ -310,6 +314,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				errJobs: []string{
 					"job-02",
 				},
+				ignoredJobs: []string{},
 			}).Detail(),
 		},
 		"returns failed status and nil when successful job count is less than total": {
@@ -347,7 +352,8 @@ func Test_statusValidator_Validate(t *testing.T) {
 				completeJobs: []string{
 					"job-01",
 				},
-				errJobs: []string{},
+				errJobs:     []string{},
+				ignoredJobs: []string{},
 			},
 		},
 		"returns succeeded status and nil when validation is success": {
@@ -386,7 +392,8 @@ func Test_statusValidator_Validate(t *testing.T) {
 					"job-01",
 					"job-02",
 				},
-				errJobs: []string{},
+				errJobs:     []string{},
+				ignoredJobs: []string{},
 			},
 		},
 		"returns succeeded status and nil when only an ignored job is failing": {
@@ -421,6 +428,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				totalJobs:    []string{"job-01"},
 				completeJobs: []string{"job-01"},
 				errJobs:      []string{},
+				ignoredJobs:  []string{"job-02", "job-03"},
 			},
 		},
 		"returns succeeded status and nil when only an ignored job is failing, with failure state": {
@@ -455,6 +463,7 @@ func Test_statusValidator_Validate(t *testing.T) {
 				totalJobs:    []string{"job-01"},
 				completeJobs: []string{"job-01"},
 				errJobs:      []string{},
+				ignoredJobs:  []string{"job-02", "job-03"},
 			},
 		},
 	}


### PR DESCRIPTION
# Overview

should close #51 

This PR improves the execution logging to make it easier to read and parse. It does this by printing the jobs as a yaml-esk list within [github actions log groups](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines).

Each bit of information is grouped:
- complete jobs
- incomplete jobs (jobs that are no other status)
- failed jobs
- all jobs
- ignored jobs

## Details
- Prints job details as a yaml-esk list 
- Uses log grouping when printing log groups
- adds a function to get incomplete jobs