### PR TITLE
Update docs to enumerate the specific permissions needed by merge-gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper-latest.yaml
+++ b/.github/workflows/merge-gatekeeper-latest.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   merge-gatekeeper:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Check out
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ on:
 jobs:
   merge-gatekeeper:
     runs-on: ubuntu-latest
+    # Restrict permissions of the GITHUB_TOKEN.
+    # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Run Merge Gatekeeper
         # NOTE: v1 is updated to reflect the latest v1.x.y. Please use any tag/branch that suits your needs:

--- a/docs/action-usage.md
+++ b/docs/action-usage.md
@@ -48,6 +48,11 @@ on:
 jobs:
   merge-gatekeeper:
     runs-on: ubuntu-latest
+    # Restrict permissions of the GITHUB_TOKEN.
+    # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Run Merge Gatekeeper
         # NOTE: v1 is updated to reflect the latest v1.x.y. Please use any tag/branch that suits your needs:

--- a/example/definitions.yaml
+++ b/example/definitions.yaml
@@ -11,6 +11,11 @@ on:
 jobs:
   merge-gatekeeper:
     runs-on: ubuntu-latest
+    # Restrict permissions of the GITHUB_TOKEN.
+    # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Run Merge Gatekeeper
         # NOTE: v1 is updated to reflect the latest v1.x.y. Please use any tag/branch that suits your needs:
@@ -35,6 +40,11 @@ jobs:
   merge-gatekeeper-custom:
     runs-on: ubuntu-latest
     name: Custom Name for Merge Gatekeeper
+    # Restrict permissions of the GITHUB_TOKEN.
+    # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Run Merge Gatekeeper
         uses: upsidr/merge-gatekeeper@main

--- a/example/merge-gatekeeper.yml
+++ b/example/merge-gatekeeper.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   merge-gatekeeper:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
     steps:
       - name: Run Merge Gatekeeper
         uses: upsidr/merge-gatekeeper@v1


### PR DESCRIPTION
See issue: https://github.com/upsidr/merge-gatekeeper/issues/62

Based on my usage of [merge-gatekeeper](https://github.com/upsidr/merge-gatekeeper), only specifying the following [permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) on the `GTHUB_TOKEN` appear sufficient:
```
checks: read
statuses: read
```

Updated the example YAML files to include these permissions. Please let me know if there are any automated tests I should update.