### PR TITLE
Add image name as input 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.16.7
+ARG IMAGE_NAME=golang
 
-FROM golang:${GO_VERSION}-alpine
+FROM ${IMAGE_NAME}:${GO_VERSION}-alpine
 
 ARG ORG=upsidr
 ARG REPO=merge-gatekeeper

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG GO_VERSION=1.16.7
-ARG IMAGE_NAME=golang
 
-FROM ${IMAGE_NAME}:${GO_VERSION}-alpine
+FROM golang:${GO_VERSION}-alpine
 
 ARG ORG=upsidr
 ARG REPO=merge-gatekeeper

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     default: "Dockerfile"
 runs:
   using: "docker"
-  image: ${{ inputs.image_name }}
+  image: ${{ INPUT_IMAGE_NAME }}
   args:
     - "validate"
     - "--token=${{ inputs.token }}"

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,13 @@ inputs:
     description: "set ref of github repository. the ref can be a SHA, a branch name, or tag name"
     required: false
     default: ${{ github.event.pull_request.head.sha }}
+  image_name:
+    description: "docker image name"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
+  build-args: IMAGE_NAME=${{ inputs.image_name }}
   args:
     - "validate"
     - "--token=${{ inputs.token }}"

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ inputs:
   image_name:
     description: "docker image name"
     required: false
+    default: "Dockerfile"
 runs:
   using: "docker"
-  image: "Dockerfile"
-  build-args: IMAGE_NAME=${{ inputs.image_name }}
+  image: ${{ inputs.image_name }}
   args:
     - "validate"
     - "--token=${{ inputs.token }}"


### PR DESCRIPTION
After the rate limit changes introduced by docker on Github actions, we're getting rate limited since the action pulls a fresh image from the docker hub on each run.

Allow changing the image name via config, which allows us to self-host/proxy the base Golang image.

Fixes #69 