### PR TITLE
github-token can be optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ branding:
 inputs:
   token:
     description: "set github token"
-    required: true
+    required: false
+    default: ${{ github.token }}
   self:
     description: "set self job name"
     required: false


### PR DESCRIPTION
Adding a GH token in secrets can be a blocker for enterprise on public repo (risk of leaking them in logs, don't ask me how I know that...).

This small trick allows to use the short-living token declared for the job.